### PR TITLE
Add orders queue

### DIFF
--- a/deploy/modules/appService.bicep
+++ b/deploy/modules/appService.bicep
@@ -50,3 +50,4 @@ resource appServiceApp 'Microsoft.Web/sites@2020-06-01' = {
 }
 
 output appServiceAppHostName string = appServiceApp.properties.defaultHostName
+


### PR DESCRIPTION
This PR adds a new Azure Storage queue for processing orders, and updates the website configuration to include the storage account and queue information.